### PR TITLE
Added downloading directories using tarfiles.

### DIFF
--- a/server.go
+++ b/server.go
@@ -103,7 +103,7 @@ func startupServer() {
 	}
 
 	glog.V(vLevel).Info("Installing handlers")
-	installHandlers()
+	setupHandlers()
 
 	glog.V(vLevel).Infof("Listening on port %d\n", *port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {

--- a/tardir.go
+++ b/tardir.go
@@ -1,0 +1,61 @@
+// Functions for tarring a directory
+
+package main
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Writes the given file to the tar
+func tarFile(rootPath, dirPath string, fi os.FileInfo, tw *tar.Writer) error {
+	relFilepath := filepath.Join(dirPath, fi.Name())
+	f, err := os.Open(filepath.Join(rootPath, relFilepath))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	th, err := tar.FileInfoHeader(fi, "")
+	if err != nil {
+		return err
+	}
+	// Sets name to the name rooted by the dirPath
+	th.Name = relFilepath
+	if err := tw.WriteHeader(th); err != nil {
+		return err
+	}
+	if _, err := io.Copy(tw, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tars an entire directory, recursing into subdirectories as well.
+// rootPath + dirPath is the absolute path of the directory, and is
+// used to find files to open, but dirPath is the actual directory
+// being compressed and is written to the tar, so it can be expanded
+// anywhere.
+func compressDir(rootPath, dirName string, tw *tar.Writer) error {
+	dir, err := os.Open(filepath.Join(rootPath, dirName))
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	files, err := dir.Readdir(0)
+	for _, fi := range files {
+		switch {
+		case fi.Name()[0] == '.':
+		case fi.IsDir():
+			if err := compressDir(rootPath, filepath.Join(dirName, fi.Name()), tw); err != nil {
+				return err
+			}
+		default:
+			if err := tarFile(rootPath, dirName, fi, tw); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,12 @@ def conf(request):
     testdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
     srcpath = os.path.abspath(testdir + '/..')
     moviepath = testdir + '/moviedir'
-    movies = [torndb.Row({'name': (dirpath + "/" + f)[len(moviepath) + 1:], 'downloads': 0})
-              for dirpath, _, files in os.walk(moviepath)
-              for f in files if len(f) > 0 and f[0] != '.']
+    # Movies includes all the non-dot directories and files plus the
+    # moviedir directory itself, as a '.'
+    movies = [torndb.Row({'name': os.path.join(dirpath, item)[len(moviepath) + 1:], 'downloads': 0})
+              for dirpath, dirnames, files in os.walk(moviepath)
+              for item in files + dirnames if len(item) > 0 and item[0] != '.']
+    movies += [torndb.Row({'name': '.', 'downloads': 0})]
     port = 10000
     db = torndb.Connection('127.0.0.1', 'movieserver', user="root")
     conf = torndb.Row({

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1,15 +1,59 @@
 # Tests the movie handler
 import requests
+import random
+import pytest
+import time
+import os.path
+import StringIO
+import tarfile
 
-def test_regular(conf):
-    for movie in conf.movies:
-        req = requests.get(conf.serveraddress + conf.handlers.movie + movie.name)
-        filetext = open(conf.moviepath + '/' + movie.name).read()
-        assert req.status_code == 200
-        # It is encoded as a binary-stream, so req.content
-        # contains the raw bytes
-        assert filetext == req.content
+def setup_module():
+    random.seed()
 
-def test_bogus(conf):
+@pytest.fixture(autouse=True)
+def cleardownloads(request, conf):
+    conf.db.execute("UPDATE movies SET downloads=0 WHERE present=TRUE")
+
+def test_files(conf):
+    confmoviefiles = [movie for movie in conf.movies
+                      if not os.path.isdir(os.path.join(conf.moviepath, movie.name))]
+    downloads = [random.randint(0, 10) for i in range(len(confmoviefiles))]
+    for i in range(len(confmoviefiles)):
+        movie = confmoviefiles[i]
+        print movie
+        for dnum in range(downloads[i]):
+            req = requests.get(conf.serveraddress + conf.handlers.movie + movie.name)
+            filetext = open(os.path.join(conf.moviepath, movie.name)).read()
+            assert req.status_code == 200
+            # It is encoded as a binary-stream, so req.content
+            # contains the raw bytes
+            assert filetext == req.content
+
+    time.sleep(1)
+    rows = conf.db.query("SELECT name, downloads FROM movies WHERE present=TRUE")
+    for i in range(len(downloads)):
+        assert [r for r in rows if r.name == confmoviefiles[i].name][0].downloads == downloads[i]
+
+def test_bogus_file(conf):
     req = requests.get(conf.serveraddress + conf.handlers.movie + 'nonexistentfile.goober')
     assert req.status_code == 404
+
+def test_directories(conf):
+    """Gets a tar for each directory in conf.movies. Then it makes sure
+    all the files are there in the tar and are equal"""
+    confmoviedirs = [movie for movie in conf.movies
+                     if os.path.isdir(os.path.join(conf.moviepath, movie.name))]
+    for movie in confmoviedirs:
+        req = requests.get(conf.serveraddress + conf.handlers.movie + movie.name)
+        tfile = tarfile.open(mode='r', fileobj=StringIO.StringIO(req.content))
+        if movie.name == '.':
+            # It's the moviedirectory itself, so the tar archive will
+            # have moviedir in it's name, so the tardir is
+            # conf.moviepath minus the ending moviedir
+            tardir = os.path.dirname(conf.moviepath)
+        else:
+            tardir = conf.moviepath
+        for name in tfile.getnames():
+            tarcontent = tfile.extractfile(name).read()
+            syscontent = open(os.path.join(tardir, name)).read()
+            assert tarcontent == syscontent

--- a/tests/test_movietable.py
+++ b/tests/test_movietable.py
@@ -4,7 +4,8 @@ import requests
 import fnmatch
 import random
 
-random.seed()
+def setup_module():
+    random.seed()
 
 def test_handler_files(conf):
     rows = conf.db.query("SELECT path, name FROM movies WHERE present=TRUE")


### PR DESCRIPTION
It creates a tar in memory every time a directory is queried for. I
modified the heartbeat to add directories. I also removed
dotfiles/dotdirectories from the movie listing, because they are
generally unneeded and create clutter. Also I refactored the server to
use filepath.Join in more places, and I beefed up testing for the movie
table handler and added tests for directories.
