### PR TITLE
Sped up querying the movies table and added notifications on frontend

### DIFF
--- a/conf/setup.sql
+++ b/conf/setup.sql
@@ -4,30 +4,16 @@ CREATE DATABASE IF NOT EXISTS movieserver
 ----------
 USE movieserver
 ----------
---#DROP TABLE IF EXISTS ips
-----------
-CREATE TABLE IF NOT EXISTS ips(
-	address VARCHAR(255) PRIMARY KEY,
-	registered TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-	KEY registered(registered)
-	)
-----------
---#DROP TABLE IF EXISTS movies
-----------
 CREATE TABLE IF NOT EXISTS movies(
-	path VARCHAR(767),
-	name VARCHAR(767),
-	downloads BIGINT UNSIGNED DEFAULT 0,
-	present BOOL DEFAULT TRUE,
-	PRIMARY KEY (path, name),
-	KEY downloads(downloads),
-	KEY present(present)
-	)
-----------
---#DROP TABLE IF EXISTS login
+        path VARCHAR(767),
+        name VARCHAR(767),
+        downloads BIGINT UNSIGNED DEFAULT 0,
+        PRIMARY KEY (path, name),
+        KEY downloads(downloads)
+        )
 ----------
 CREATE TABLE IF NOT EXISTS login(
-	user VARCHAR(255),
-	password VARCHAR(255),
-	PRIMARY KEY (user, password)
-	)
+        user VARCHAR(255),
+        password VARCHAR(255),
+        PRIMARY KEY (user, password)
+        )

--- a/frontend/js/startup.js
+++ b/frontend/js/startup.js
@@ -64,8 +64,7 @@ requirejs.config({
   }
 });
 
-requirejs(['jquery', 'app'], function($, App) {
-  $.getJSON('tableKeys/', function(data) {
-    App.initialize(data);
-  });
+requirejs(['jquery', 'underscore', 'app'], function($, _, App) {
+  setInterval(_.bind(App.poller, App), 1000);
+  App.initialize();
 });

--- a/frontend/stylesheets/styles.css
+++ b/frontend/stylesheets/styles.css
@@ -36,3 +36,8 @@ body {
   border: 0px;
   background-color: transparent;
 }
+#no-data-alert,
+#no-connection-alert,
+#no-keys-alert {
+  display: none;
+}

--- a/frontend/stylesheets/styles.less
+++ b/frontend/stylesheets/styles.less
@@ -40,3 +40,7 @@ body {
     border: 0px;
     background-color: transparent;
 }
+
+#no-data-alert, #no-connection-alert, #no-keys-alert {
+    display:none;
+}

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -31,6 +31,7 @@ specific language governing permissions and limitations under the License.
 
   <body>
     <div class="container">
+
       <div class="row">
         <nav class="navbar" role="navigation">
           <!-- Brand and toggle get grouped for better mobile display -->
@@ -56,6 +57,20 @@ specific language governing permissions and limitations under the License.
         <div id="paginatorBox" class="col-12 text-center">
         </div>
       </div>
+
+      <div class="row">
+        <div id="no-data-alert" class="alert alert-info">
+          Please wait while the server reindexes this folder...
+        </div>
+        <div id="no-keys-alert" class="alert alert-info">
+          Received no windows from the server. There is likely a
+          problem with the server.
+        </div>
+        <div id="no-connection-alert" class="alert alert-danger">
+          Lost connection to the server. Polling...
+        </div>
+      </div>
+
     </div>
   </body>
 </html>

--- a/handlers.go
+++ b/handlers.go
@@ -29,7 +29,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -41,40 +40,6 @@ const (
 	loginURL       = "/"
 	checkAccessURL = "/checkAccess/"
 )
-
-var (
-	// Since running COUNT(*) on a very large movie entry set can
-	// take a while, we store a mapping from where clauses to
-	// index size, so that we don't have to rerun the COUNT(*)
-	// when we're on the same movie set on a where clause we've
-	// already seen. Every time the movie indexer runs, it will
-	// clear this map, since it's creating a new movie set. This
-	// is okay, because this map is really only useful for very
-	// large movie sets, and reindexing very large indexes takes a
-	// while, so it would be cleared infrequently
-	fileCount struct {
-		index map[string]uint64
-		// We need to control concurrent access to the fileCount map,
-		// since the movie indexer writes to it, and each table
-		// handler thread reads from it
-		lock sync.RWMutex
-	}
-)
-
-// Read locks the fileCount and reads the given key
-func fileCountRead(key string) (uint64, bool) {
-	fileCount.lock.RLock()
-	count, ok := fileCount.index[key]
-	fileCount.lock.RUnlock()
-	return count, ok
-}
-
-// Write locks the fileCount and writes the given key-value pair
-func fileCountWrite(key string, value uint64) {
-	fileCount.lock.Lock()
-	fileCount.index[key] = value
-	fileCount.lock.Unlock()
-}
 
 // Launches the login template when the user opens up http://[ip]:[port]/
 func loginHandler(w http.ResponseWriter, r *http.Request) {
@@ -107,10 +72,7 @@ type movieRow struct {
 // template. Otherwise, it serves the file named by the path
 func mainHandler(w http.ResponseWriter, r *http.Request) {
 	if len(r.URL.Path) == len(mainURL) {
-		if err := runTemplate("index", w, nil); err != nil {
-			glog.Error(err)
-			http.Error(w, "Failed to fetch home page", http.StatusInternalServerError)
-		}
+		http.ServeFile(w, r, filepath.Join(*srcPath, "frontend", "templates", "index.html"))
 	} else {
 		http.ServeFile(w, r, filepath.Join(*srcPath, r.URL.Path[len(mainURL):]))
 	}
@@ -174,10 +136,10 @@ func addQueryParams(r *http.Request, moviePath string) (map[string]paramPair, er
 	// always
 	if filterString := queryParams.Get("q"); filterString != "" {
 		fixedString := string(convertFilterString([]byte(filterString))) + "%"
-		paramMap["where"] = paramPair{" AND path = ? AND name LIKE ?",
+		paramMap["where"] = paramPair{" path = ? AND name LIKE ?",
 			[]interface{}{moviePath, fixedString}}
 	} else {
-		paramMap["where"] = paramPair{" AND path = ?", []interface{}{moviePath}}
+		paramMap["where"] = paramPair{" path = ?", []interface{}{moviePath}}
 	}
 
 	if sort_col, order := queryParams.Get("sort_by"), queryParams.Get("order"); len(sort_col+order) > 0 {
@@ -204,10 +166,10 @@ func addQueryParams(r *http.Request, moviePath string) (map[string]paramPair, er
 	return paramMap, nil
 }
 
-// Serves the movies and downloads that are present from the movie
-// table as a JSON object. It returns pagination settings for the
-// client side paginator object in the JSON as well. The first segment
-// in the url is the key of the movie path.
+// Serves the movies and downloads of the requested table from the
+// movie table as a JSON object. It returns pagination settings for
+// the client side paginator object in the JSON as well. The first
+// segment in the url is the key of the movie path.
 func tableHandler(w http.ResponseWriter, r *http.Request) {
 	httpError := func(err error, code int) {
 		glog.Errorf("Error in table handler: %s", err)
@@ -243,23 +205,11 @@ func tableHandler(w http.ResponseWriter, r *http.Request) {
 	// in paginationState to 1 and use a limit offset of 0
 	var total_entries uint64
 
-	// First we check if the count is already in the fileCount
-	fileCountKey := fmt.Sprint(paramMap["where"].args)
-	if count, ok := fileCountRead(fileCountKey); ok {
-		total_entries = count
-	} else {
-		// We need to run a COUNT(*) query. We only need the
-		// WHERE param arg
-		glog.V(vvLevel).Info("Running COUNT(*) over the movie index")
-		countRow := trans.QueryRow(fmt.Sprintf(sqlStatements["getMovieNum"], paramMap["where"].str), paramMap["where"].args...)
-		if err := countRow.Scan(&total_entries); err != nil {
-			httpError(err, http.StatusInternalServerError)
-			return
-		}
-		// Update fileCount
-		fileCountWrite(fileCountKey, total_entries)
+	countRow := trans.QueryRow(fmt.Sprintf(sqlStatements["getMovieNum"], paramMap["where"].str), paramMap["where"].args...)
+	if err := countRow.Scan(&total_entries); err != nil {
+		httpError(err, http.StatusInternalServerError)
+		return
 	}
-
 	paginationState := map[string]interface{}{
 		"total_entries": total_entries,
 	}
@@ -375,7 +325,6 @@ func movieHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		tw.Close()
-		w.Header().Set("Content-Type", "binary/octet-stream")
 		rs = bytes.NewReader(buf.Bytes())
 	} else {
 		f, err := os.Open(filelocation)
@@ -399,10 +348,12 @@ func movieHandler(w http.ResponseWriter, r *http.Request) {
 	res, err := dbHandle.Exec(sqlStatements["addDownload"], moviePath, filename)
 	if err != nil {
 		glog.Errorf("Error updating download count for %s: %s", filename, err)
+		return;
 	}
 	rowcount, err := res.RowsAffected()
 	if err != nil {
 		glog.Error("Error retrieving rows affected for addDownload query")
+		return;
 	}
 	if rowcount == 0 {
 		panic("Update changed 0 rows, so it should have thrown an error above")
@@ -410,7 +361,6 @@ func movieHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func setupHandlers() error {
-	fileCount.index = make(map[string]uint64)
 	http.HandleFunc(mainURL, mainHandler)
 	http.HandleFunc(tableURL, tableHandler)
 	http.HandleFunc(movieURL, movieHandler)

--- a/server.go
+++ b/server.go
@@ -119,7 +119,7 @@ func startupServer() {
 	}
 
 	glog.V(vLevel).Info("Fetching html templates")
-	if err := fetchTemplates("login", "index"); err != nil {
+	if err := fetchTemplates("login"); err != nil {
 		glog.Error(err)
 		return
 	}

--- a/sql_interface.go
+++ b/sql_interface.go
@@ -100,42 +100,36 @@ func setupSchema() error {
 // Adds some predefined SQL statements to a map
 func buildSQLMap() {
 	// newMovie adds a movie to the movies table. If the movie is
-	// already there, it sets present to TRUE
-	sqlStatements["newMovie"] = "INSERT INTO movies(path, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE present=TRUE"
+	// already there, it will throw a dup key error
+	sqlStatements["newMovie"] = "INSERT INTO movies(path, name) VALUES (?, ?)"
+
+	// deleteMovie deletes a movie from the table. If there is no
+	// movie, it won't do anything, but it will say that 0 rows
+	// were affected
+	sqlStatements["deleteMovie"] = "DELETE FROM movies where path=? and name=?";
+
 	// addDownload increments the number of downloads for an
 	// existing movie. If the movie isn't there, it won't throw an
 	// error, but it will say that 0 rows were affected.
 	sqlStatements["addDownload"] = "UPDATE movies SET downloads=downloads+1 WHERE path=? AND name=?"
 
 	// getMovies selects all the movie names and downloads from
-	// the movies table that are present. The three %s's are meant
-	// for additional WHERE clauses, ORDER BY, and LIMIT
-	sqlStatements["getMovies"] = "SELECT name, downloads FROM movies WHERE present = TRUE %s %s %s"
+	// the movies table that are in moviePaths paths. The three
+	// %s's are meant for WHERE clauses, ORDER BY, and LIMIT
+	sqlStatements["getMovies"] = "SELECT name, downloads FROM movies WHERE %s %s %s"
 
 	// getMovieNum is the same as getMovies except it's a COUNT(*)
 	// query. We don't need ORDER BY and LIMIT, though.
-	sqlStatements["getMovieNum"] = "SELECT COUNT(*) FROM movies WHERE present = TRUE %s"
+	sqlStatements["getMovieNum"] = "SELECT COUNT(*) FROM movies WHERE %s"
 
 	// getUserAndPassword selects the row that matches a given
 	// username-password combination
 	sqlStatements["getUserAndPassword"] = "SELECT user from login WHERE user = ? AND password = ?"
 }
 
-// Sets up the schema, builds the query map, and sets all file entries
-// which aren't in the moviePaths to present=False. This has to be
-// done before the indexer starts indexing, so that the server doesn't
-// accidentely return the wrong set of files to the client. Since it
-// only has to be done once, we don't need to put it in the heartbeat
+// Sets up the schema and builds the query map
 func startupDB() error {
 	if err := setupSchema(); err != nil {
-		return err
-	}
-	moviePathStr := strings.Repeat("?, ", len(moviePaths)-1) + "?"
-	moviePathArgs := make([]interface{}, 0, len(moviePaths))
-	for _, v := range moviePaths {
-		moviePathArgs = append(moviePathArgs, v)
-	}
-	if _, err := dbHandle.Exec(fmt.Sprintf("UPDATE movies SET present=FALSE WHERE path NOT IN (%s)", moviePathStr), moviePathArgs...); err != nil {
 		return err
 	}
 	buildSQLMap()

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -12,7 +12,8 @@ def setup_module():
 
 @pytest.fixture(autouse=True)
 def cleardownloads(request, conf):
-    conf.db.execute("UPDATE movies SET downloads=0 WHERE present=TRUE")
+    pathstr = ', '.join(["%s"] * len(conf.paths))
+    conf.db.execute(("UPDATE movies SET downloads=0 WHERE path IN (%s)" % pathstr), *conf.paths.values())
 
 def test_files(conf):
     for tableKey, path in conf.paths.iteritems():
@@ -28,10 +29,10 @@ def test_files(conf):
                 # It is encoded as a binary-stream, so req.content
                 # contains the raw bytes
                 assert filetext == req.content
-
         time.sleep(1)
+
         for i in range(len(downloads)):
-            rows = conf.db.query("SELECT name, downloads FROM movies WHERE present=TRUE AND path=%s AND name=%s", path, confmoviefiles[i].name)
+            rows = conf.db.query("SELECT downloads FROM movies WHERE path=%s AND name=%s", path, confmoviefiles[i].name)
             assert len(rows) == 1
             assert rows[0].downloads == downloads[i]
 


### PR DESCRIPTION
- Backend
  *\* Removed ips table, since we aren't going to use that
  *\* Redid movies table to only include path/name as primary key and downloads.
  This way we can search by path and name, which should be a
  clustered index. Even though setting present to TRUE and FALSE
  preserves the download count for deleted files, that's not
  necessary behavior, and also including deleted files in the
  database slows down searching
  *\* Redid movie indexing in the heartbeat
  Deleting and then re-inserting every file entry we find is very
  slow. Instead, we now maintain a copy of the currently used files
  in a map in memory, and every time the indexer runs, it
  adds/deletes only the necessary entries from the database and
  updates the in-memory map.
  *\* Eliminated the fileCount map
  Since we don't need to search with present=TRUE anymore, the
  COUNT(*) query runs very quickly even on large (+200000
  entries) directories, so it's unneccessary.
- Frontend
  *\* Added an alert and poller for when the connection to the server drops
  *\* Added an alert and poller for when the server is still indexing a directory
  *\* Minor refactors
